### PR TITLE
fix: export nm_vpn_editor_plugin_factory from main plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,14 @@ target_link_options(nm-vpn-plugin-amneziawg-core PRIVATE)
 add_library(nm-vpn-plugin-amneziawg SHARED)
 target_sources(nm-vpn-plugin-amneziawg PRIVATE
     $<TARGET_OBJECTS:nm-vpn-plugin-amneziawg-utils>
+    properties/nm-amneziawg-editor-plugin.c
+    properties/nm-amneziawg-editor-plugin.h
+)
+target_include_directories(nm-vpn-plugin-amneziawg PRIVATE ${CMAKE_SOURCE_DIR}/shared ${CMAKE_BINARY_DIR})
+target_compile_options(nm-vpn-plugin-amneziawg PRIVATE
+    ${COMMON_CFLAGS} ${COMMON_DEFINITIONS} ${PROPERTIES_CPPFLAGS}
+    -DNETWORKMANAGER_COMPILATION=NM_NETWORKMANAGER_COMPILATION_LIB_EDITOR
+    -DNM_PLUGIN_DIR=\"${NM_PLUGIN_DIR}\"
 )
 target_link_libraries(nm-vpn-plugin-amneziawg PRIVATE ${COMMON_LDFLAGS} nm-vpn-plugin-amneziawg-core ${LIBNM_LIBRARIES} ${CMAKE_DL_LIBS})
 set_target_properties(nm-vpn-plugin-amneziawg PROPERTIES


### PR DESCRIPTION
Adds the editor-plugin source to the main plugin target so libnm can load the VPN config import/export factory.

Fixes #7 

Verification:

- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_GTK3=ON -DWITH_GTK4=ON` — succeeded
- `nm -D --defined-only build/libnm-vpn-plugin-amneziawg.so | grep nm_vpn_editor_plugin_factory` → `00000000000045a0 T nm_vpn_editor_plugin_factory`
- `nm -D --defined-only build/libnm-vpn-plugin-amneziawg-editor.so | grep nm_vpn_editor_factory_amneziawg` → `0000000000009250 T nm_vpn_editor_factory_amneziawg`
- `ctest --test-dir build` → 1/1 passed