### PR TITLE
fix: support old and current AmneziaWG kernel ABIs

### DIFF
--- a/shared/amneziawg.c
+++ b/shared/amneziawg.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <glib.h>
 #include <linux/genetlink.h>
 #include <linux/if_link.h>
 #include <linux/netlink.h>
@@ -23,6 +24,41 @@
 #include <unistd.h>
 
 #include "amneziawg.h"
+#include "awg/awg-validate.h"
+
+/*
+ * Kernel ABI for AmneziaWG changed between versions:
+ *  - magic headers (H1..H4) were NUL strings in old kernels and became
+ *    packed u64 ranges (u32_range_t, hi<<32|lo) in newer ones;
+ *  - peer keepalive interval was u16 and became u32.
+ * Detect the format from the loaded module version (3.x = new ABI,
+ * older = legacy). When the version cannot be read, default to the new
+ * ABI and fall back to legacy if the kernel rejects the request.
+ */
+static bool
+awg_kernel_uses_current_abi(bool *known)
+{
+    const char *path = "/sys/module/amneziawg/version";
+    char buf[64];
+    FILE *f;
+    unsigned major;
+
+    *known = false;
+    f = fopen(path, "r");
+    if (!f)
+        return true;
+    if (fgets(buf, sizeof(buf), f) == NULL) {
+        fclose(f);
+        return true;
+    }
+    fclose(f);
+
+    if (sscanf(buf, "%u", &major) != 1)
+        return true;
+
+    *known = true;
+    return major >= 3;
+}
 
 /* wireguard.h netlink uapi: */
 
@@ -430,6 +466,32 @@ static void
 mnl_attr_put_u32(struct nlmsghdr *nlh, uint16_t type, uint32_t data)
 {
     mnl_attr_put(nlh, type, sizeof(uint32_t), &data);
+}
+
+static void
+mnl_attr_put_u64(struct nlmsghdr *nlh, uint16_t type, uint64_t data)
+{
+    mnl_attr_put(nlh, type, sizeof(uint64_t), &data);
+}
+
+static void
+mnl_attr_put_strz(struct nlmsghdr *nlh, uint16_t type, const char *data);
+
+static void
+awg_mnl_attr_put_magic_header(struct nlmsghdr *nlh, uint16_t type, const char *str, bool current_abi)
+{
+    guint32 lo, hi;
+
+    /* Old kernels parse the "start-end" range themselves from a NUL string;
+     * newer ones expect a packed u32_range_t (u64 = hi<<32 | lo).
+     */
+    if (!current_abi) {
+        mnl_attr_put_strz(nlh, type, str);
+        return;
+    }
+
+    if (awg_magic_header_parse(str, &lo, &hi))
+        mnl_attr_put_u64(nlh, type, ((uint64_t)hi << 32) | lo);
 }
 
 static void
@@ -1130,6 +1192,7 @@ int
 wg_set_device(wg_device *dev)
 {
     int ret = 0;
+    bool current_abi, known_abi;
     wg_peer *peer = NULL;
     wg_allowedip *allowedip = NULL;
     struct nlattr *peers_nest, *peer_nest, *allowedips_nest, *allowedip_nest;
@@ -1139,6 +1202,8 @@ wg_set_device(wg_device *dev)
     nlg = mnlg_socket_open(WG_GENL_NAME, WG_GENL_VERSION);
     if (!nlg)
         return -errno;
+
+    current_abi = awg_kernel_uses_current_abi(&known_abi);
 
 again:
     nlh = mnlg_msg_prepare(nlg, WG_CMD_SET_DEVICE, NLM_F_REQUEST | NLM_F_ACK);
@@ -1168,13 +1233,13 @@ again:
         if (dev->flags & WGDEVICE_HAS_S4)
             mnl_attr_put_u16(nlh, WGDEVICE_A_S4, dev->transport_packet_junk_size);
         if (dev->flags & WGDEVICE_HAS_H1 && dev->init_packet_magic_header)
-            mnl_attr_put_strz(nlh, WGDEVICE_A_H1, dev->init_packet_magic_header);
+            awg_mnl_attr_put_magic_header(nlh, WGDEVICE_A_H1, dev->init_packet_magic_header, current_abi);
         if (dev->flags & WGDEVICE_HAS_H2 && dev->response_packet_magic_header)
-            mnl_attr_put_strz(nlh, WGDEVICE_A_H2, dev->response_packet_magic_header);
+            awg_mnl_attr_put_magic_header(nlh, WGDEVICE_A_H2, dev->response_packet_magic_header, current_abi);
         if (dev->flags & WGDEVICE_HAS_H3 && dev->underload_packet_magic_header)
-            mnl_attr_put_strz(nlh, WGDEVICE_A_H3, dev->underload_packet_magic_header);
+            awg_mnl_attr_put_magic_header(nlh, WGDEVICE_A_H3, dev->underload_packet_magic_header, current_abi);
         if (dev->flags & WGDEVICE_HAS_H4 && dev->transport_packet_magic_header)
-            mnl_attr_put_strz(nlh, WGDEVICE_A_H4, dev->transport_packet_magic_header);
+            awg_mnl_attr_put_magic_header(nlh, WGDEVICE_A_H4, dev->transport_packet_magic_header, current_abi);
         if (dev->flags & WGDEVICE_HAS_I1 && dev->i1)
             mnl_attr_put_strz(nlh, WGDEVICE_A_I1, dev->i1);
         if (dev->flags & WGDEVICE_HAS_I2 && dev->i2)
@@ -1219,7 +1284,8 @@ again:
                     goto toobig_peers;
             }
             if (peer->flags & WGPEER_HAS_PERSISTENT_KEEPALIVE_INTERVAL) {
-                if (!mnl_attr_put_u16_check(nlh, mnl_ideal_socket_buffer_size(), WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL, peer->persistent_keepalive_interval))
+                if (!(current_abi ? mnl_attr_put_u32_check(nlh, mnl_ideal_socket_buffer_size(), WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL, peer->persistent_keepalive_interval)
+                                  : mnl_attr_put_u16_check(nlh, mnl_ideal_socket_buffer_size(), WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL, peer->persistent_keepalive_interval)))
                     goto toobig_peers;
             }
         }
@@ -1289,6 +1355,21 @@ send:
     errno = 0;
     if (mnlg_socket_recv_run(nlg, NULL, NULL) < 0) {
         ret = errno ? -errno : -EINVAL;
+        /* If we guessed the wrong ABI (module version unreadable), recreate
+         * the interface and retry once with the legacy formats. */
+        if (ret == -EINVAL && !known_abi) {
+            known_abi = true;
+            current_abi = false;
+            peer = NULL;
+            allowedip = NULL;
+            ret = add_del_iface(dev->name, false);
+            if (ret < 0)
+                goto out;
+            ret = add_del_iface(dev->name, true);
+            if (ret < 0)
+                goto out;
+            goto again;
+        }
         goto out;
     }
     if (peer)


### PR DESCRIPTION
## Summary

Add compatibility with both legacy and current AmneziaWG kernel netlink ABIs.

The plugin previously always serialized magic headers and persistent keepalive values using the legacy ABI. Current AmneziaWG kernel modules expect different netlink attribute types, causing VPN activation to fail during device configuration.

## Problem

The AmneziaWG netlink ABI changed between kernel module versions:

- Legacy modules use NUL-terminated strings for H1-H4 magic header ranges
- Current modules use packed `u64` values for H1-H4
- Legacy modules use `u16` for the peer persistent keepalive interval
- Current modules use `u32` for the peer persistent keepalive interval

`shared/amneziawg.c` always sent H1-H4 as strings and keepalive as `u16`.

With a current 3.x AmneziaWG module, the kernel rejects these attributes because their payload sizes and types do not match the current ABI. `WG_CMD_SET_DEVICE` returns `EINVAL`, and NetworkManager reports:

```text
Failed to set device <interface>
```

Simply switching to the current format would break systems still using legacy 1.x and 2.x modules, so the userspace plugin needs to support both ABIs.

## Changes

### Detect the loaded AmneziaWG kernel ABI

Read `/sys/module/amneziawg/version` before configuring the device:

- Version 3.x and newer uses the current ABI
- Older versions use the legacy ABI
- If the module version cannot be read or parsed, default to the current ABI and retain a legacy fallback

The detection is local to each `wg_set_device()` call and does not introduce mutable global state.

### Serialize H1-H4 in the format expected by the kernel

Legacy kernels continue receiving the original NUL-terminated strings.

For current kernels, the existing `awg_magic_header_parse()` validator parses each magic header range. The resulting range is packed into the `u64` format expected by the kernel:

```c
((uint64_t)end << 32) | start
```

### Use the correct persistent keepalive attribute size

Persistent keepalive is serialized according to the detected ABI:

- `u16` for legacy kernels
- `u32` for current kernels

### Fall back safely when the module version is unavailable

If the version could not be detected and the current ABI request is rejected with `EINVAL`, the plugin:

1. Switches to the legacy attribute formats
2. Resets peer and allowed-IP iteration state
3. Recreates the interface to start from a clean state
4. Retries the complete configuration once

Errors while recreating the interface are propagated instead of being ignored.

## Testing

Tested the same service binary against both ABI generations.

### Current ABI

AmneziaWG module `3.1.20260812`:

- NetworkManager connection activates successfully
- Interface `awg-a267d11e` is created and brought up
- Address `10.8.2.13/32` is assigned
- No netlink attribute length errors are reported

### Legacy ABI

AmneziaWG module `1.0.20260611`:

- NetworkManager connection activates successfully
- Interface `awg-54305b8a` is created and brought up
- Address `10.8.2.2/32` is assigned
- Legacy H1-H4 and keepalive formats continue to work

### Local checks

- Project builds successfully
- `nm-amneziawg-service` builds successfully
- Existing `ctest` suite passes
- Modified source passes `clang-format`
